### PR TITLE
fix .bashrc method, which was not loading if the env in docker-stacks…

### DIFF
--- a/jupyter_tensorboard_proxy/__init__.py
+++ b/jupyter_tensorboard_proxy/__init__.py
@@ -1,4 +1,3 @@
-import re
 import os
 import shutil
 import logging

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setuptools.setup(
     name="jupyter-tensorboard-proxy",
-    version='0.2.0',
+    version='0.2.1',
     url="https://github.com/kopwei/jupyter-tensorboard-proxy",
     author="kopkop",
     description="kopkop@gmail.com",


### PR DESCRIPTION
Added .bashrc parsing to a /tmp/.tensorboard file if the relevant env vars are specified in .bashrc instead of ~/.tensorboard.
Why? Because in some contexts like docker-stacks, the user may not have a guarantee that the .bashrc is sourced in the runtime session when the tensorboard proxy is clicked/launched. But at the same time, the user may prefer to use only a ~/.bashrc. With just one additional TF_LOG_DIR var, they can direct tensorboard to look for logs in that location, and use the same AWS s3 credentials as their other projects, without keeping duplicates in 2 files. Other libraries won't look for ~/.tensorboard. But it exists when you want to curate maybe a separate s3 bucket just for this.